### PR TITLE
Fix scaling issue ins some mobile devices

### DIFF
--- a/site.ts
+++ b/site.ts
@@ -37,7 +37,7 @@ const style = `
         border: 1px solid #f0f0f0;
         border-radius: 8px;
         padding-top: 5px;
-        width: 380px;
+        max-width: 380px;
         box-shadow: -6px 0 16px -8px rgb(0 0 0 / 8%), -9px 0 28px 0 rgb(0 0 0 / 5%), -12px 0 48px 16px rgb(0 0 0 / 3%);
     }
     .form textarea {
@@ -118,7 +118,7 @@ const style = `
         border: 1px solid #f0f0f0;
         border-radius: 8px;
         box-shadow: -6px 0 16px -8px rgb(0 0 0 / 8%), -9px 0 28px 0 rgb(0 0 0 / 5%), -12px 0 48px 16px rgb(0 0 0 / 3%);
-        width: 340px;
+        max-width: 340px;
         margin-block-end: 1em;
     }
     .bolded { font-weight: 600; }


### PR DESCRIPTION
The form was bigger than few device viewports.

Image with issue: 
<img width="737" alt="CleanShot 2022-11-20 at 04 33 55@2x" src="https://user-images.githubusercontent.com/109241881/202874974-6bdde393-cae1-4353-9554-8b9f655674eb.png">

380px should have worked theoretically, but there's extra spacing, so form need to be a bit narrower.

